### PR TITLE
Update `README.md` to include more thorough, up-to-date procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ root@forum:~# sudo nano /etc/mailname
 forum.dev.spinalcordmri.org
 ```
 
-Additionally, edit the `/etc/hosts` file to ensure it contains the line `127.0.0.1 forum.dev.neuropoly.org localhost`:
+Additionally, edit the `/etc/hosts` file to ensure that it looks like the following:
 
 ```console
 root@forum:~# sudo nano /etc/hosts
@@ -190,7 +190,8 @@ root@forum:~# sudo nano /etc/hosts
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 #
-127.0.0.1 forum.dev.spinalcordmri.org localhost
+127.0.1.1 forum.dev.spinalcordmri.org
+127.0.0.1 localhost
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 localhost ip6-localhost ip6-loopback

--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ Connect to the droplet server provided by Digital Ocean, then do:
       #DISCOURSE_SMTP_PORT: 587
       DISCOURSE_SMTP_USER_NAME: user@example.com
       DISCOURSE_SMTP_PASSWORD: pa$$word
-    + DISCOURSE_SMTP_OPEN_TIMEOUT: 30
-    + DISCOURSE_SMTP_READ_TIMEOUT: 30
+    + DISCOURSE_SMTP_OPEN_TIMEOUT: 60
+    + DISCOURSE_SMTP_READ_TIMEOUT: 60
       #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
       #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)
       #DISCOURSE_NOTIFICATION_EMAIL: noreply@discourse.example.com    # (address to send notifications from)
@@ -409,6 +409,8 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
     ```
    
     It will run some automated tests, then it will prompt you for an email to send a test message to.
+
+    > _**NB**: There is a possibility that you may encounter a `Net::ReadTimeout` error. In that case, edit the `/var/discourse/containers/app.yml` file to increase the values of `DISCOURSE_SMTP_OPEN_TIMEOUT` and `DISCOURSE_SMTP_READ_TIMEOUT`. Then, restart the docker container by running `cd /var/discourse`, `./launcher destroy app`, and `./launcher start app`._
 
 With each of these tests, your goal here is to ensure that:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# https://spinalcordmri.org
+# `spinalcordmri.org`
 
-This repo contains the source code and documentation for the https://spinalcordmri.org/ website. 
-
-## Main website (`spinalcordmri.org`)
+This repo contains the source code and documentation for the https://spinalcordmri.org/ website.
 
 The main website is a simple landing page written using the Jekyll static site generator, and is deployed and hosted using GitHub Pages. The website uses a custom domain name purchased from NameCheap, then linked with GitHub Pages. (This way, instead of https://spinalcordmri.github.io, we get to use https://spinalcordmri.org.)
 
@@ -18,7 +16,7 @@ Configuration is relatively simple, and was done using instructions from the fol
 - **GitHub Pages**: https://help.github.com/articles/quick-start-setting-up-a-custom-domain/
 - **NameCheap**: https://www.namecheap.com/support/knowledgebase/article.aspx/9645/2208/how-do-i-link-my-domain-to-github-pages
 
-## SCT Forum (`forum.spinalcordmri.org`)
+# `forum.spinalcordmri.org`
 
 The webforum ["forum.spinalcordmri.org"](https://forum.spinalcordmri.org/) is a subdomain of the spinalcordmri.org website. The forum was [originally envisioned](https://github.com/neuropoly/onboarding/issues/71#issuecomment-1008948573) as a general web forum and community for discussing MRI processing, acquisition, etc. That being said, the spinalcordmri.org forum is often colloquially referred to as the "SCT Forum", because the most active part of the forum is the ["SCT"](https://forum.spinalcordmri.org/c/sct/8) subsection. 
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ First, connect to the server using either SSH or the built-in DigitalOcean conso
 ```console
 root@forum:~# sudo nano /etc/hostname
 forum.dev.spinalcordmri.org
-root@forum:~# sudo nano /etc/hostname
+root@forum:~# sudo nano /etc/mailname
 forum.dev.spinalcordmri.org
 ```
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Navigate to the page https://forum.dev.spinalcordmri.org/, and follow the instru
 
 Ideally, we should have a backup of the Discourse forum saved somewhere, such that you can load the backup into the new forum installation and be up and running like normal.
 
-Also, you may want to install important plugins such as `discourse-solved`.
+Also, you may want to install important plugins such as `discourse-solved` at this time, too.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's
     - `useradd -s /usr/sbin/nologin forum` : Creates the user account.
     - `passwd forum`: Sets the password for the account. Paste the password you generated earlier.
 
-> _**NB**: This username is *not* the same as what's on the email headers, because `opensmtpd` allows authenticated users to spoof their identities, and we want to send as `noreply@forum.dev.spinalcordtoolbox.org`.
+> _**NB**: This username is *not* the same as what's on the email headers, because `opensmtpd` allows authenticated users to spoof their identities, and we want to send as `noreply@forum.dev.spinalcordtoolbox.org`._
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -275,11 +275,11 @@ These files must be present for `opensmtpd` to be able to send mail correctly, a
 
 #### 5.2 Test mail delivery
 
-To create the first admin account on the newly-installed Discourse forum, you will need to ensure that email delivery is working.
+To create the first admin account on the newly-installed Discourse forum, email delivery must be working, because Discourse will need to send out a confirmation email.
 
-To test this, rather than sending messages to specific personal addresses, we use https://www.mail-tester.com/. This page is very helpful for finding issues missed during setup, especially around spamminess. Email is very very complicated and this helps a lot.
+To test email delivery, rather than sending messages to specific personal addresses, we use https://www.mail-tester.com/. This page is very helpful for finding issues missed during setup, especially around spamminess. Email is very very complicated and this helps a lot.
 
-Go to https://www.mail-tester.com/ and copy the email address it gives you. You can use this address in one of three ways:
+Go to https://www.mail-tester.com/ and copy the email address it gives you. You can use this address alongside one of three testing methods:
 
 0. Prerequisite step: Opening logs
 
@@ -297,7 +297,7 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
 
     ```bash
     # You will need to enter the password that you set during the previous "User Setup" section!!
-    swaks --to me@example.com --from noreply@forum.spinalcordmri.org --server forum.spinalcordmri.org -p 25 --auth-user forum --tls-verify --tls
+    swaks --to me@example.com --from noreply@forum.spinalcordmri.org --server forum.spinalcordmri.org -p 587 --auth-user forum --tls-verify --tls
     ```
 
 3. Discourse-specific test

--- a/README.md
+++ b/README.md
@@ -199,16 +199,19 @@ forum.dev.spinalcordmri.org
 
 We run a small mail server on the same server as Discourse for it to send notifcations and password resets. Discourse recommends using a cloud service like MailGun or Amazon SES or SendGrid, but our usage is so small that the overhead (and risk) of outsourcing is high. Mail servers are something of an arcane art now, but never fear, these instructions will make it work.
 
-
 #### 4.1 Install mail server
 
-First, we must install [`opensmtpd`](https://www.opensmtpd.org/). However, we cannot use 
+First, we must install [`opensmtpd`](https://www.opensmtpd.org/). However, we cannot use `sudo apt-get install opensmtpd` because of [a buggy interaction with OpenSSL 3.0](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171), which Ubuntu 22.10 installs by default.
 
-```
-sudo apt-get install opensmtpd
-```
+To get around this, we must build `openssl` and `opensmtpd` from their source code, to ensure that `opensmptd` uses OpenSSL v1.1.1, rather than v3.0.
 
-The installer will prompt you to name the system; make sure to tell it "forum.spinalcordmri.org".
+Thankfully, one of SCT's developers has created a script that will automate this procedure.
+
+1. Run `cd ~`, then create a new file called `patch_opensmtpd_openssl.sh` and paste in the contents of [this comment](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171#issuecomment-1218503481):
+2. Make the script executable using `chmod +x patch_opensmtpd_openssl.sh`.
+3. Run the script using `./patch_opensmtpd_openssl.sh`
+
+> _**NB:**: The `opensmtpd` installer will prompt you to name the system; make sure to tell it "forum.dev.spinalcordmri.org"._
 
 #### 4.2 Configure mail server
 

--- a/README.md
+++ b/README.md
@@ -312,13 +312,14 @@ cd /var/discourse
 - Install Discourse
 ~~~
 ./discourse-setup
-Hostname      : forum.dev.spinalcordmri.org
-Email         : [initial administrator's email address]
-SMTP address  : forum.dev.spinalcordmri.org
-SMTP port     : 587
-SMTP username : forum
-SMTP password : xxxxxxxxxxxxxxxxxxxxxxx
-Let's Encrypt : [initial administrator's email address]
+Hostname        : forum.dev.spinalcordmri.org
+Email           : [initial administrator's email address]
+SMTP address    : forum.dev.spinalcordmri.org
+SMTP port       : 587
+SMTP username   : forum
+SMTP password   : xxxxxxxxxxxxxxxxxxxxxxx
+Let's Encrypt   : [initial administrator's email address]
+Maxmind License : [Enter}
 ~~~
 
 #### 5.2 Check SSL certs

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Thankfully, one of SCT's developers has created a script that will automate this
 2. Make the script executable using `chmod +x patch_opensmtpd_openssl.sh`.
 3. Run the script using `./patch_opensmtpd_openssl.sh`
 
-> _**NB:**: The `opensmtpd` installer will prompt you to name the system; make sure to tell it "forum.dev.spinalcordmri.org"._
+> _**NB:**: During the installation, a purple text UI will appear on the screen prompting you to answer some questions. For **Daemons using outdated libraries**, keep the default selections; Just press enter. For **Configuring opensmtpd**, enter in "forum.dev.spinalcordmri.org" for the system mail name, then press enter.._
 
 You can verify that `opensmptd` was built and installed correctly by running:
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ If you need to remake the forum's VM from scratch (e.g. to debug an issue withou
 
 ----
 
-- 0. [Domain name](#0-domain-name)
-- 1. [Digital Ocean](#1-digitalocean)
-- 2. [Namecheap](#2-namecheap)
-- 3. [Hostnames](#3-server-setup-hostnames)
-- 4. [Email](#4-server-setup-email)
-- 5. [Discourse](#5-server-setup-discourse)
-- 6. [Google/GitHub logins](#6-googlegithub-logins-for-discourse)
+0. [Domain name](#0-domain-name)
+1. [Digital Ocean](#1-digitalocean)
+2. [Namecheap](#2-namecheap)
+3. [Hostnames](#3-server-setup-hostnames)
+4. [Email](#4-server-setup-email)
+5. [Discourse](#5-server-setup-discourse)
+6. [Google/GitHub logins](#6-googlegithub-logins-for-discourse)
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ These entries accomplish the following:
 
 1. [A Record](https://support.dnsimple.com/articles/a-record/): Maps the `forum.dev.spinalcordmri.org` subdomain to the DigitalOcean droplet's IP address.
 2. [SPF Record](https://spfrecord.io/syntax/): This will help later on when setting up the forum's mail server. It authorizes the DigitalOcean droplet as a valid sender of mail, which helps prevent the forum's notification emails from being caught as spam.
-3. [DMARC Record](https://mxtoolbox.com/dmarc/details/what-is-a-dmarc-record): This will help later on when setting up the forum's mail server. 
+3. [DMARC Record](https://mxtoolbox.com/dmarc/details/what-is-a-dmarc-record): This will help later on when setting up the forum's mail server. It defines what should happen in case a message sent by the forum fails to be authenticated.
 
 You can double-check the current values by running the following commands:
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
-# spinalcordmri.github.io
+# https://spinalcordmri.org
 
-## Configure Domain (NameCheap)
+This repo contains the source code and documentation for the https://spinalcordmri.org/ website. 
 
-- Purchase domain, e.g. from Namecheap
-- configure it to the GH page: https://help.github.com/articles/quick-start-setting-up-a-custom-domain/
-- Link domain to GitHub Pages:  https://www.namecheap.com/support/knowledgebase/article.aspx/9645/2208/how-do-i-link-my-domain-to-github-pages
+The website is written using the Jekyll static site generator, and is deployed and hosted using GitHub Pages. The website uses a custom domain name purchased from NameCheap, then linked with GitHub Pages. (This way, instead of https://spinalcordmri.github.io, we get to use https://spinalcordmri.org.)
 
-The configuration looks like this:
+Configuration settings can be found here:
 
-| Type         | Host                    | Value                   | TTL       |
-|--------------|-------------------------|-------------------------|-----------|
-| CNAME Record | www                     | spinalcordmri.github.io | Automatic |
-| A Record     | @                       | 185.199.110.153         | Automatic |
-| A Record     | @                       | 185.199.108.153         | Automatic |
-| A Record     | @                       | 185.199.109.153         | Automatic |
-| A Record     | @                       | 185.199.111.153         | Automatic |
-| A Record     | forum.spinalcordmri.org | 159.89.119.65           | Automatic |
+- **GitHub Pages**: https://github.com/spinalcordmri/spinalcordmri.github.io/settings/pages
+- **NameCheap**: https://ap.www.namecheap.com/Domains/DomainControlPanel/spinalcordmri.org/domain/
 
+Configuration is relatively simple, and was done using instructions from the following pages:
+
+- **GitHub Pages**: https://help.github.com/articles/quick-start-setting-up-a-custom-domain/
+- **NameCheap**: https://www.namecheap.com/support/knowledgebase/article.aspx/9645/2208/how-do-i-link-my-domain-to-github-pages
 
 ## Set up Discourse Forum
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,15 @@ If you need to remake the forum's VM from scratch (e.g. to debug an issue withou
 
 > _**NB**: The following instructions are heavily based off of Discourse's official Cloud Installation instructions found [here](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md). If anything is unclear, it may be helpful to refer to those instructions for further guidance._
 
-### 0. Choosing a domain name
+----
+
+### 0. Domain name
 
 Before you begin, first choose an [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) (i.e. a domain name). This can be `forum.spinalcordmri.org` if you're starting completely from scratch (i.e. there is no currently-running forum instance) or something like `forum.dev.spinalcordmri.org` (if you're setting up a separate test server).
 
 > _**NB**: For the rest of these instructions, we will use the `forum.dev.spinalcordmri.org` hostname, but make sure you substitute in whichever domain name you decided on._
+
+----
 
 ### 1. DigitalOcean
 
@@ -87,6 +91,8 @@ Or, you can navigate to your droplet's main page, then click the "Console" butto
 ![image](https://user-images.githubusercontent.com/16181459/207170763-68db34b0-4f1d-4e6d-a7b6-72340994c7ae.png)
 
 From here, you can make changes to the server itself. 
+
+----
 
 ### 2. Namecheap
 
@@ -146,6 +152,8 @@ user@device:~$ dig +short MX forum.dev.spinalcordmri.org
 0 forum.dev.spinalcordmri.org.
 ```
 
+----
+
 ### 3. Server Setup: Hostnames
 
 Now that NameCheap is configured, we can set up the server itself, starting with its hostname.
@@ -165,6 +173,8 @@ Make sure that both of these files contain only the domain name you chose. Addit
 root@forum:~# hostname
 forum.dev.spinalcordmri.org
 ```
+
+----
 
 ### 4. Server Setup: Discourse
 
@@ -197,6 +207,9 @@ Other ways to side-step this:
 1. Run letsencrypt ourselves, outside of the Discourse container; make sure that works and then say "No" to the Let's Encrypt prompt.
 1. Run a second letsencrypt account for the same domain outside of the Discourse container?
 1. Run the mail server on a separate server e.g. `mail.spinalcordmri.org` with its own independent subdomain and certificates.
+
+
+----
 
 ### 5. Setup Email
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,23 @@ If you need to remake the forum's VM from scratch (e.g. to debug an issue withou
 
 > _**NB**: The following instructions are heavily based off of Discourse's official Cloud Installation instructions found [here](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md). If anything is unclear, it may be helpful to refer to those instructions for further guidance._
 
-### DigitalOcean
+### 1. DigitalOcean
 
 Create account & droplet in Digital Ocean. Droplet configure : 1GB RAM, 1 vCPU,25 GB HDD,	1 TB transfer, running Ubuntu 18.04-LTS.
 
-### Setup subdomain in namecheap
+### 2. Namecheap
+
   - To create a subdomain, please do the following:
     - Go to your Domain List and click Manage next to the domain
     - Select the Advanced DNS tab
     - Find the Host Records section and click on the Add New Record button
     - Select A Record for Type and enter the Host `forum.spinalcordmri.org`  you would like to point to an IP address `DigitalOcean_Server_IP_Address`
 
-### System Hostname
+### 3. System Hostname
 
 Make sure that the Droplet's `/etc/hostname` contains "forum.spinalcordmri.org".
 
-### Setup Discourse server
+### 4. Setup Discourse server
 
 Connect to the droplet server provided by Digital Ocean, then do:
   * Install Docker:
@@ -77,7 +78,7 @@ Other ways to side-step this:
 1. Run a second letsencrypt account for the same domain outside of the Discourse container?
 1. Run the mail server on a separate server e.g. `mail.spinalcordmri.org` with its own independent subdomain and certificates.
 
-### Setup Email
+### 5. Setup Email
 
 We run a small mail server on the same server as Discourse for it to send notifcations and password resets. Discourse recommends using a cloud service like MailGun or Amazon SES or SendGrid, but our usage is so small that the overhead (and risk) of outsourcing is high. Mail servers are something of an arcane art now, but never fear, these instructions will make it work.
 
@@ -91,7 +92,7 @@ root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org
 ```
 
 
-#### Install mail server
+#### 5.1 Install mail server
 
 Install [`opensmtpd`](https://www.opensmtpd.org/):
 
@@ -120,7 +121,7 @@ Afterwards, make sure that `/etc/mailname` contains "forum.spinalcordmri.org".
 
 Despite this bug, setting up `opensmtpd` is still leagues simpler and more reliable than `postfix` or `sendmail`.
 
-##### Setup DNS for Email
+#### 5.2 Setup DNS for Email
 
 1. Again, triple-check that `cat /etc/hostname` and `cat /etc/mailname` and `hostname` all return "forum.spinalcordmri.org"; **if not**, edit those two files manually, then **reboot** and check again.
 1. In NameCheap, under the "forum.spinalcordmri.org" subdomain:
@@ -133,7 +134,7 @@ Despite this bug, setting up `opensmtpd` is still leagues simpler and more relia
 3. Reverse DNS: log in to the Droplet's control panel at DigitalOcean (DO) and *set the name of the Droplet* to "forum.spinalcordmri.org"; this [causes the reverse DNS to be defined](https://www.digitalocean.com/community/questions/how-do-i-set-up-reverse-dns-for-my-ip).
     * to test: `dig +short -x $(dig +short forum.spinalcordmri.org)` should return "forum.spinalcordmri.org".
 
-##### Configure mail server
+#### 5.3 Configure mail server
 
 Put this into `/etc/smtpd.conf`:
 
@@ -165,7 +166,7 @@ journalctl -f -u opensmtpd
 (it helps to run this in a separate tab while doing the rest of the configuration and testing)
 
 
-##### Test mail delivery
+#### 5.4 Test mail delivery
 
 At this point the mail server *should* be a member of the internet email community. To test, use:
 
@@ -188,7 +189,7 @@ then click the "View My Results" button.
 
 Review until you have a good score and mails are getting accepted.
 
-#### Configure Discourse's email account
+#### 5.5 Configure Discourse's email account
 
 We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's users by default, so we will make an OS user for outgoing emails. This username is *not* the same as what's on the email headers: `opensmtpd` allows authenticated users to spoof their identities, and we need actually want that because we want to send as `noreply@forum.spinalcordtoolbox.org`.
 

--- a/README.md
+++ b/README.md
@@ -215,11 +215,9 @@ We run a small mail server on the same server as Discourse for it to send notifc
 
 #### 4.1 Install mail server
 
-First, we must install [`opensmtpd`](https://www.opensmtpd.org/). However, we cannot use `sudo apt-get install opensmtpd` because of [a buggy interaction with OpenSSL 3.0](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171), which Ubuntu 22.04 installs by default.
+First, we must install our mail server software of choice, [`opensmtpd`](https://www.opensmtpd.org/). 
 
-To get around this, we must build `openssl` and `opensmtpd` from their source code, to ensure that `opensmptd` uses OpenSSL v1.1.1, rather than v3.0.
-
-Thankfully, one of SCT's developers has created a script that will automate this procedure.
+However, we cannot use `sudo apt-get install opensmtpd` because of [a buggy interaction with OpenSSL 3.0](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171), which Ubuntu 22.04 installs by default. To get around this, we must build `openssl` and `opensmtpd` from their source code, to ensure that `opensmptd` uses OpenSSL v1.1.1, rather than v3.0. Thankfully, one of SCT's developers (@kousu) has created a script that will automate this procedure:
 
 1. Run `cd ~`, then create a new file called `patch_opensmtpd_openssl.sh` and paste in the contents of [this comment](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171#issuecomment-1218503481):
 2. Make the script executable using `chmod +x patch_opensmtpd_openssl.sh`.

--- a/README.md
+++ b/README.md
@@ -191,24 +191,6 @@ sudo apt-get install opensmtpd
 
 The installer will prompt you to name the system; make sure to tell it "forum.spinalcordmri.org".
 
-**There is a bug** in the OpenSMTPd packaged for Ubuntu 18.04: https://bugs.launchpad.net/ubuntu/+source/opensmtpd/+bug/1840586. To work around it, apply this patch:
-
-```
---- /lib/systemd/system/opensmtpd.service.old	2020-11-05 01:20:51.164473166 +0000
-+++ /lib/systemd/system/opensmtpd.service	2020-11-03 21:22:34.309085523 +0000
-@@ -6,7 +6,8 @@
- [Service]
- Type=forking
- ExecStart=/usr/sbin/smtpd
--ExecStop=/usr/sbin/smtpctl stop # backported fix for https://bugs.launchpad.net/ubuntu/+source/opensmtpd/+bug/1840586
-+ExecStop=/bin/kill -15 $MAINPID
- 
- [Install]
- WantedBy=multi-user.target
-```
-
-Despite this bug, setting up `opensmtpd` is still leagues simpler and more reliable than `postfix` or `sendmail`.
-
 #### 4.2 Configure mail server
 
 Put this into `/etc/smtpd.conf`:

--- a/README.md
+++ b/README.md
@@ -346,7 +346,9 @@ This will download the Discourse base image, then build the image and initialize
 
 #### 5.2 Check SSL certs
 
-Before continuing, make sure that Discourse has generated its SSL certs. (They will be [generated automatically](https://meta.discourse.org/t/set-up-https-support-with-lets-encrypt/40709), as long as you provide an email address for Let's Encrypt.) They exist in `/var/discourse/shared/standalone/ssl/`:
+Before continuing, make sure that Discourse has generated its SSL certs. (They will be [generated automatically](https://meta.discourse.org/t/set-up-https-support-with-lets-encrypt/40709), so long as you provide an email address for Let's Encrypt.) 
+
+The files exist in `/var/discourse/shared/standalone/ssl/`:
 
 ```
 root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.{cer,key}
@@ -354,7 +356,7 @@ root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri
 -rw------- 1 root root 3247 Dec  5 08:33 /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.key
 ```
 
-These files must be present for `opensmtpd` to be able to send mail correctly, as per the configuration in `/etc/smtpd.conf`. 
+These files must be present for `opensmtpd` to be able to send mail correctly, as per the previous `/etc/smtpd.conf`  configuration we pasted in during a previous step. 
 
 #### 5.3 Starting the mail server
 

--- a/README.md
+++ b/README.md
@@ -86,29 +86,11 @@ forum.dev.spinalcordmri.org.
 
 Once you've confirmed that it returns the domain name you chose, you're all set to connect to the droplet.
 
-#### 1.2 Connecting to the droplet for the first time
-
-You can connect to the server either through SSH (assuming your local device contains the SSH key you added earlier):
-
-```console
-user@device:~$ ssh root@forum.dev.spinalcordmri.org
-Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-50-generic x86_64)
-
-Last login: Fri Dec  9 23:06:11 2022 from 162.243.188.66
-root@forum:~# 
-```
-
-Or, you can navigate to your droplet's main page, then click the "Console" button in the top-left corner:
-
-![image](https://user-images.githubusercontent.com/16181459/207170763-68db34b0-4f1d-4e6d-a7b6-72340994c7ae.png)
-
-From here, you can make changes to the server itself. 
-
 ----
 
 ### 2. Namecheap
 
-Before we make any changes to the server, we first have to configure some DNS settings.
+Before we make any changes to the server, though, we first have to configure some DNS settings.
 
 First, make sure you have an account with Namecheap. Again, you will need to contact someone on the admin team; they will grant you permissions for specific domains on a case-by-case basis. In this case, you will want access to the spinalcordmri.org domain, which will grant you access to the [Spinalcordmri.org Dashboard](https://ap.www.namecheap.com/domains/domaincontrolpanel/spinalcordmri.org/domain).
 
@@ -170,6 +152,26 @@ user@device:~$ dig +short MX forum.dev.spinalcordmri.org
 ### 3. Server Setup: Hostnames
 
 Now that NameCheap is configured, we can set up the server itself, starting with its hostname.
+
+#### 3.1 Connecting to the droplet for the first time
+
+You can connect to the server either through SSH (assuming your local device contains the SSH key you added earlier):
+
+```console
+user@device:~$ ssh root@forum.dev.spinalcordmri.org
+Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-50-generic x86_64)
+
+Last login: Fri Dec  9 23:06:11 2022 from 162.243.188.66
+root@forum:~# 
+```
+
+Or, you can navigate to your droplet's main page, then click the "Console" button in the top-left corner:
+
+![image](https://user-images.githubusercontent.com/16181459/207170763-68db34b0-4f1d-4e6d-a7b6-72340994c7ae.png)
+
+From here, you can make changes to the server itself. 
+
+#### 3.2 Updating the hosts and hostname files
 
 First, connect to the server using either SSH or the built-in DigitalOcean console. Next, edit two files using the text editor of your choice:
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ SMTP password : xxxxxxxxxxxxxxxxxxxxxxx
 Let's Encrypt : [initial administrator's email address]
 ~~~
 
-Before continuing, make sure that Discourse has generated its SSL certs. They exist in `/var/discourse/shared/standalone/ssl/`:
+Before continuing, make sure that Discourse has generated its SSL certs. (They will be [generated automatically](https://meta.discourse.org/t/set-up-https-support-with-lets-encrypt/40709), as long as you provide an email address for Let's Encrypt.) They exist in `/var/discourse/shared/standalone/ssl/`:
 
 ```
 root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.{cer,key}
@@ -271,7 +271,7 @@ root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org
 -rw------- 1 root root 3247 Dec  5 08:33 /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.key
 ```
 
-These files are necessary for `opensmtpd` to be able to send mail correctly, as per the configuration in `/etc/smtpd.conf`.
+These files must be present for `opensmtpd` to be able to send mail correctly, as per the configuration in `/etc/smtpd.conf`. 
 
 #### 5.2 Test mail delivery
 

--- a/README.md
+++ b/README.md
@@ -176,42 +176,7 @@ forum.dev.spinalcordmri.org
 
 ----
 
-### 4. Server Setup: Discourse
-
-Connect to the droplet server provided by Digital Ocean, then do:
-  * Install Docker:
-~~~
-wget -qO- https://get.docker.com/ | sh
-~~~
-- Clone Discourse deploy
-~~~
-mkdir /var/discourse
-git clone https://github.com/discourse/discourse_docker.git /var/discourse
-cd /var/discourse
-~~~
-- Install Discourse
-~~~
-./discourse-setup
-Hostname      : forum.spinalcordmri.org
-Email         : [initial administrator's email address]
-SMTP address  : [press Enter]
-SMTP port     : [press Enter]
-SMTP username : [press Enter]
-SMTP password : [press Enter]
-Let's Encrypt : [press Enter]
-~~~
-
-Note that this skips SMTP (email). We run a mail server on the same machine as Discourse, so there is a circular dependency that we need to side-step: the mail server relies on Discourse to generate a SSL certificate, but Discourse needs a mail server to operate.
-
-Other ways to side-step this:
-1. Run letsencrypt ourselves, outside of the Discourse container; make sure that works and then say "No" to the Let's Encrypt prompt.
-1. Run a second letsencrypt account for the same domain outside of the Discourse container?
-1. Run the mail server on a separate server e.g. `mail.spinalcordmri.org` with its own independent subdomain and certificates.
-
-
-----
-
-### 5. Setup Email
+### 4. Server Setup: Email
 
 We run a small mail server on the same server as Discourse for it to send notifcations and password resets. Discourse recommends using a cloud service like MailGun or Amazon SES or SendGrid, but our usage is so small that the overhead (and risk) of outsourcing is high. Mail servers are something of an arcane art now, but never fear, these instructions will make it work.
 
@@ -225,7 +190,7 @@ root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org
 ```
 
 
-#### 5.1 Install mail server
+#### 4.1 Install mail server
 
 Install [`opensmtpd`](https://www.opensmtpd.org/):
 
@@ -254,7 +219,7 @@ Afterwards, make sure that `/etc/mailname` contains "forum.spinalcordmri.org".
 
 Despite this bug, setting up `opensmtpd` is still leagues simpler and more reliable than `postfix` or `sendmail`.
 
-#### 5.2 Configure mail server
+#### 4.2 Configure mail server
 
 Put this into `/etc/smtpd.conf`:
 
@@ -286,7 +251,7 @@ journalctl -f -u opensmtpd
 (it helps to run this in a separate tab while doing the rest of the configuration and testing)
 
 
-#### 5.3 Test mail delivery
+#### 4.3 Test mail delivery
 
 At this point the mail server *should* be a member of the internet email community. To test, use:
 
@@ -309,7 +274,7 @@ then click the "View My Results" button.
 
 Review until you have a good score and mails are getting accepted.
 
-#### 5.4 Configure Discourse's email account
+#### 4.4 Configure Discourse's email account
 
 We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's users by default, so we will make an OS user for outgoing emails. This username is *not* the same as what's on the email headers: `opensmtpd` allows authenticated users to spoof their identities, and we need actually want that because we want to send as `noreply@forum.spinalcordtoolbox.org`.
 
@@ -343,6 +308,42 @@ We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's
       Let's Encrypt : [press Enter]
       ```
 5. Test: make a post on the forum, and have someone else reply to it. Watch the mail log (`journalctl -u -f opensmtpd`!) and check if you receive the notification in your inbox.
+
+----
+
+### 5. Server Setup: Discourse
+
+Connect to the droplet server provided by Digital Ocean, then do:
+  * Install Docker:
+~~~
+wget -qO- https://get.docker.com/ | sh
+~~~
+- Clone Discourse deploy
+~~~
+mkdir /var/discourse
+git clone https://github.com/discourse/discourse_docker.git /var/discourse
+cd /var/discourse
+~~~
+- Install Discourse
+~~~
+./discourse-setup
+Hostname      : forum.spinalcordmri.org
+Email         : [initial administrator's email address]
+SMTP address  : [press Enter]
+SMTP port     : [press Enter]
+SMTP username : [press Enter]
+SMTP password : [press Enter]
+Let's Encrypt : [press Enter]
+~~~
+
+Note that this skips SMTP (email). We run a mail server on the same machine as Discourse, so there is a circular dependency that we need to side-step: the mail server relies on Discourse to generate a SSL certificate, but Discourse needs a mail server to operate.
+
+Other ways to side-step this:
+1. Run letsencrypt ourselves, outside of the Discourse container; make sure that works and then say "No" to the Let's Encrypt prompt.
+1. Run a second letsencrypt account for the same domain outside of the Discourse container?
+1. Run the mail server on a separate server e.g. `mail.spinalcordmri.org` with its own independent subdomain and certificates.
+
+----
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ If you need to remake the forum's VM from scratch (e.g. to debug an issue withou
 
 ----
 
+### Table of contents
+
 0. [Domain name](#0-domain-name)
 1. [Digital Ocean](#1-digitalocean)
 2. [Namecheap](#2-namecheap)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ user@device:~$ dig +short TXT _dmarc.forum.dev.spinalcordmri.org
 "v=DMARC1; p=none"
 ```
 
-> _**NB**: If you make a mistake and want to update the values of these records, please note that it may take [up to a few hours](https://ns1.com/resources/dns-propagation) for changes to these records to propagate. So, if you're running `dig` and see no change, that's why!_
+> _**NB**: Please note that it may take [up to a few hours](https://ns1.com/resources/dns-propagation) for changes to these records to propagate. So, if you're running `dig` and see no change, that's why!_
 
 #### 2.2 Mail Settings (i.e. MX Records)
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ Next, on the dashboard, navigate to the [Advanced DNS tab](https://ap.www.namech
 
 #### 2.1 Host Records
 
-First you will want to make note the subdomain label of your domain name. For `forum.dev.spinalcordmri.org`, you will use `forum.dev` to identify your subdomain.
+First you will want to make note of two things:
 
-Next, you will want to mark down the IP address you noted in Step 1. For `forum.dev.spinalcordmri.org`, the IP address was `142.93.152.255`.
+1. The subdomain label of your domain name. For `forum.dev.spinalcordmri.org`, you will use `forum.dev` to identify your subdomain.
+2. The IP address of the server (from step 1). For `forum.dev.spinalcordmri.org`, the IP address was `142.93.152.255`.
 
 You can now use the red "Add New Record" button to add 3 new records in the following form:
 

--- a/README.md
+++ b/README.md
@@ -339,11 +339,12 @@ Once you send your test message, you can click "View my results" on the mail-tes
 
 ----
 
+### 6. Google/GitHub logins for Discourse
 
+<details>
+<summary> Note: These steps are not currently used in the production server for spinalcordmri.org </summary>
 
-```
-
-### Configuring Google login for Discourse ([reference](https://meta.discourse.org/t/configuring-google-login-for-discourse/15858))
+#### 6.1 Configuring Google login for Discourse ([reference](https://meta.discourse.org/t/configuring-google-login-for-discourse/15858))
 
 Go to https://console.developers.google.com, click on Credentials and create a new Project.
 - Project name `Forum spinalcordmri`
@@ -363,7 +364,8 @@ Configure your OAuth Consent Screen
 Click Library in the left menu and you’ll see a huge list of Google API’s. Find Google+ API and enable them.
 
 The API will create `google_client_id` and `google_client_secret` which you can add under http://forum.spinalcordmri.org/admin/site_settings/category/login, after checking `enable google oauth2 logins`
-### Configure GitHub login for Discourse ([reference](https://meta.discourse.org/t/configuring-github-login-for-discourse/13745))
+
+#### 6.2  Configure GitHub login for Discourse ([reference](https://meta.discourse.org/t/configuring-github-login-for-discourse/13745))
 
 Under github.com/spinalcordmri, click Settings (the gear icon), then look for OAuth Applications in the left menu. Select Register new application.
   - Application name
@@ -384,13 +386,4 @@ Under github.com/spinalcordmri, click Settings (the gear icon), then look for OA
   ~~~
 The app will create `github_client_id` and `github_client_secret`which you can add under http://forum.spinalcordmri.org/admin/site_settings/category/login, after checking `enable github logins`
 
-## Debugging
-
-Check what IP are associated with the URL:
-~~~
-host spinalcordmri.org
-~~~
-Check that domain exists, and get info about registrar:
-~~~
-whois spinalcordmri.org
-~~~
+</details>

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ However, we cannot use `sudo apt-get install opensmtpd` because of [a buggy inte
 1. Run `cd ~`, then create a new file called `patch_opensmtpd_openssl.sh` and paste in the contents of [this comment](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171#issuecomment-1218503481):
 2. Make the script executable using `chmod +x patch_opensmtpd_openssl.sh`.
 3. Run the script using `./patch_opensmtpd_openssl.sh`
+4. Grab a coffee and find something interested to read. This step will take a while!
 
 > _**NB:**: During the installation, a purple text UI will appear on the screen prompting you to answer some questions. For **Daemons using outdated libraries**, keep the default selections; Just press enter. For **Configuring opensmtpd**, enter in "forum.dev.spinalcordmri.org" for the system mail name, then press enter.._
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,16 @@ With each of these tests, your goal here is to ensure that:
 
 Once you send your test message, you can click "View my results" on the mail-tester webpage. It will give you feedback on things that need to be changed. So, try to iteratively address the feedback, send a new test message, and refresh the page until you get a high score.
 
+#### 5.5 Create your first admin account
+
+Navigate to the page https://forum.dev.spinalcordmri.org/, and follow the instruction to create an admin email account. Discourse will send you a confirmation email. If you've set up mail correctly, you should receive the email and be able to finish making your account.
+
+#### 5.6 Configure the forum
+
+Ideally, we should have a backup of the Discourse forum saved somewhere, such that you can load the backup into the new forum installation and be up and running like normal.
+
+Also, you may want to install important plugins such as `discourse-solved`.
+
 ----
 
 ### 6. Google/GitHub logins for Discourse

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ From the Spinal Cord MRI project page, you can create a new "droplet", which is 
 
 Next, create a droplet using the following settings:
 
-  - **Choose an image**: Distribution -> Ubuntu -> Version: 22.10 x64
+  - **Choose an image**: Distribution -> Ubuntu -> Version: 22.04 (LTS) x64
   - **Choose a plan**: 
     - Shared CPU: Basic
     - CPU Options: Regular
@@ -92,7 +92,7 @@ You can connect to the server either through SSH (assuming your local device con
 
 ```console
 user@device:~$ ssh root@forum.dev.spinalcordmri.org
-Welcome to Ubuntu 22.10 (GNU/Linux 5.19.0-26-generic x86_64)
+Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.15.0-50-generic x86_64)
 
 Last login: Fri Dec  9 23:06:11 2022 from 162.243.188.66
 root@forum:~# 
@@ -213,7 +213,7 @@ We run a small mail server on the same server as Discourse for it to send notifc
 
 #### 4.1 Install mail server
 
-First, we must install [`opensmtpd`](https://www.opensmtpd.org/). However, we cannot use `sudo apt-get install opensmtpd` because of [a buggy interaction with OpenSSL 3.0](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171), which Ubuntu 22.10 installs by default.
+First, we must install [`opensmtpd`](https://www.opensmtpd.org/). However, we cannot use `sudo apt-get install opensmtpd` because of [a buggy interaction with OpenSSL 3.0](https://github.com/OpenSMTPD/OpenSMTPD/issues/1171), which Ubuntu 22.04 installs by default.
 
 To get around this, we must build `openssl` and `opensmtpd` from their source code, to ensure that `opensmptd` uses OpenSSL v1.1.1, rather than v3.0.
 

--- a/README.md
+++ b/README.md
@@ -299,29 +299,31 @@ We need an SMTP account that Discourse can send mail via. `opensmtpd` simply use
 #### 5.1 Initial Setup
 
 Connect to the droplet server provided by Digital Ocean, then do:
-  * Install Docker:
-~~~
-wget -qO- https://get.docker.com/ | sh
-~~~
+- Install Docker:
+    ```
+    wget -qO- https://get.docker.com/ | sh
+    ```
 - Clone Discourse deploy
-~~~
-mkdir /var/discourse
-git clone https://github.com/discourse/discourse_docker.git /var/discourse
-cd /var/discourse
-~~~
+    ```
+    mkdir /var/discourse
+    git clone https://github.com/discourse/discourse_docker.git /var/discourse
+    cd /var/discourse
+    ```
 - Install Discourse
-~~~
-./discourse-setup
-Hostname        : forum.dev.spinalcordmri.org
-Email           : [initial administrator's email address]
-SMTP address    : forum.dev.spinalcordmri.org
-SMTP port       : 587
-SMTP username   : forum
-SMTP password   : xxxxxxxxxxxxxxxxxxxxxxx
-Notification    : noreply@forum.dev.spinalcordmri.org
-Let's Encrypt   : [initial administrator's email address]
-Maxmind License : [Enter]
-~~~
+    ```
+    ./discourse-setup
+    Hostname        : forum.dev.spinalcordmri.org
+    Email           : [initial administrator's email address]
+    SMTP address    : forum.dev.spinalcordmri.org
+    SMTP port       : 587
+    SMTP username   : forum
+    SMTP password   : xxxxxxxxxxxxxxxxxxxxxxx
+    Notification    : noreply@forum.dev.spinalcordmri.org
+    Let's Encrypt   : [initial administrator's email address]
+    Maxmind License : [Enter]
+    ```
+
+This will download the Discourse base image, then build the image and initialize the Docker container.
 
 #### 5.2 Check SSL certs
 
@@ -414,21 +416,21 @@ The API will create `google_client_id` and `google_client_secret` which you can 
 
 Under github.com/spinalcordmri, click Settings (the gear icon), then look for OAuth Applications in the left menu. Select Register new application.
   - Application name
-  ~~~
+  ```
   Forum spinalcordmri
-  ~~~
+  ```
   - Homepage URL
-  ~~~
+  ```
   http://forum.dev.spinalcordmri.org/
-  ~~~
+  ```
   - Application description
-  ~~~
+  ```
   Forum spinalcordmri
-  ~~~
+  ```
   - Authorization callback URL
-  ~~~
+  ```
   http://forum.dev.spinalcordmri.org//auth/github/callback
-  ~~~
+  ```
 The app will create `github_client_id` and `github_client_secret`which you can add under http://forum.dev.spinalcordmri.org/admin/site_settings/category/login, after checking `enable github logins`
 
 </details>

--- a/README.md
+++ b/README.md
@@ -167,7 +167,26 @@ root@forum:~# sudo nano /etc/mailname
 forum.dev.spinalcordmri.org
 ```
 
-Make sure that both of these files contain only the domain name you chose. Additionally, ensure that the following command also returns the same domain name:
+Additionally, edit the `/etc/hosts` file to ensure it contains the line `127.0.0.1 forum.dev.neuropoly.org localhost`:
+
+```console
+root@forum:~# sudo nano /etc/hosts
+# Your system has configured 'manage_etc_hosts' as True.
+# As a result, if you wish for changes to this file to persist
+# then you will need to either
+# a.) make changes to the master file in /etc/cloud/templates/hosts.debian.tmpl
+# b.) change or remove the value of 'manage_etc_hosts' in
+#     /etc/cloud/cloud.cfg or cloud-config from user-data
+#
+127.0.0.1 forum.dev.spinalcordmri.org localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1 localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+```
+
+Finally, ensure that the following command also returns the same domain name as above:
 
 ```console
 root@forum:~# hostname

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
 
 0. Prerequisite step: Opening logs
 
-   Start a new, separate connection into the server, and run `journalctl -u -f opensmtpd`. This will run in the background while you perform other tests.
+   Start a new, separate connection into the server, and run `journalctl -f -u opensmtpd`. This will run in the background while you perform other tests.
 
 1. Simple test (`mail`)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # spinalcordmri.github.io
 
-## How to set up Jekyll
-
-Nice tutorials here:
-https://www.taniarascia.com/make-a-static-website-with-jekyll/
-
 ## Configure Domain (NameCheap)
 
 - Purchase domain, e.g. from Namecheap

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ SMTP address    : forum.dev.spinalcordmri.org
 SMTP port       : 587
 SMTP username   : forum
 SMTP password   : xxxxxxxxxxxxxxxxxxxxxxx
+Notification    : noreply@forum.dev.spinalcordmri.org
 Let's Encrypt   : [initial administrator's email address]
 Maxmind License : [Enter}
 ~~~

--- a/README.md
+++ b/README.md
@@ -271,15 +271,7 @@ And make the following change:
 +ExecStart=/usr/sbin/smtpd -v
 ```
 
-#### 4.4 Starting the mail server
-
-You can now start the server with the following command:
-
-```
-systemctl enable --now opensmtpd
-```
-
-#### 4.5 Create a new mail-specific user account
+#### 4.4 Create a new mail-specific user account
 
 We need an SMTP account that Discourse can send mail via. `opensmtpd` simply uses the OS's users by default, so we will make an OS user for outgoing emails.
 
@@ -337,7 +329,15 @@ root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri
 
 These files must be present for `opensmtpd` to be able to send mail correctly, as per the configuration in `/etc/smtpd.conf`. 
 
-#### 5.3 Test mail delivery
+#### 5.3 Starting the mail server
+
+Once you've confirmed that the SSL certs are present, you can start the mail server with the following command:
+
+```
+systemctl enable --now opensmtpd
+```
+
+#### 5.4 Test mail delivery
 
 To create the first admin account on the newly-installed Discourse forum, email delivery must be working, because Discourse will need to send out a confirmation email.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ These entries accomplish the following:
 2. [SPF Record](https://spfrecord.io/syntax/): This will help later on when setting up the forum's mail server. It authorizes the DigitalOcean droplet as a valid sender of mail, which helps prevent the forum's notification emails from being caught as spam.
 3. [DMARC Record](https://mxtoolbox.com/dmarc/details/what-is-a-dmarc-record): This will help later on when setting up the forum's mail server. It defines what should happen in case a message sent by the forum fails to be authenticated.
 
-You can double-check the current values by running the following commands:
+You can double-check the current values by running the following `dig` commands **from an external device**, not the server itself:
 
 ```console
 user@device:~$ dig +short forum.dev.spinalcordmri.org

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ SMTP username   : forum
 SMTP password   : xxxxxxxxxxxxxxxxxxxxxxx
 Notification    : noreply@forum.dev.spinalcordmri.org
 Let's Encrypt   : [initial administrator's email address]
-Maxmind License : [Enter}
+Maxmind License : [Enter]
 ~~~
 
 #### 5.2 Check SSL certs

--- a/README.md
+++ b/README.md
@@ -346,10 +346,6 @@ To test email delivery, rather than sending messages to specific personal addres
 
 Go to https://www.mail-tester.com/ and copy the email address it gives you. You can use this address alongside one of three testing methods:
 
-0. Prerequisite step: Opening logs
-
-   Start a new, separate connection into the server, and run `journalctl -f -u opensmtpd`. This will run in the background while you perform other tests.
-
 1. Simple test (`mail`)
 
     You will first need to install [Mailutils](https://mailutils.org/) using `sudo apt-get install mailutils`. Then, you can run:
@@ -379,7 +375,6 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
 
 With each of these tests, your goal here is to ensure that:
 
-- Nothing fishy shows up in the logs.
 - The email message gets delivered.
 - Your mail-tester score is relatively high (ideally at least 9/10, but at the very minimum, 7/10).
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,16 @@ Once you've confirmed that the SSL certs are present, you can start the mail ser
 systemctl enable --now opensmtpd
 ```
 
-#### 5.4 Test mail delivery
+#### 5.4 Test mail server connectivity
+
+You should be able to connect to the mail server by running:
+
+```console
+root@forum:~# nc forum.dev.spinalcordmri.org 587
+220 forum.dev.spinalcordmri.org ESMTP OpenSMTPD
+```
+
+#### 5.5 Test mail delivery
 
 To create the first admin account on the newly-installed Discourse forum, email delivery must be working, because Discourse will need to send out a confirmation email.
 
@@ -380,11 +389,11 @@ With each of these tests, your goal here is to ensure that:
 
 Once you send your test message, you can click "View my results" on the mail-tester webpage. It will give you feedback on things that need to be changed. So, try to iteratively address the feedback, send a new test message, and refresh the page until you get a high score.
 
-#### 5.5 Create your first admin account
+#### 5.6 Create your first admin account
 
 Navigate to the page https://forum.dev.spinalcordmri.org/, and follow the instruction to create an admin email account. Discourse will send you a confirmation email. If you've set up mail correctly, you should receive the email and be able to finish making your account.
 
-#### 5.6 Configure the forum
+#### 5.7 Configure the forum
 
 Ideally, we should have a backup of the Discourse forum saved somewhere, such that you can load the backup into the new forum installation and be up and running like normal.
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ SMTP password : xxxxxxxxxxxxxxxxxxxxxxx
 Let's Encrypt : [initial administrator's email address]
 ~~~
 
+#### 5.2 Check SSL certs
+
 Before continuing, make sure that Discourse has generated its SSL certs. (They will be [generated automatically](https://meta.discourse.org/t/set-up-https-support-with-lets-encrypt/40709), as long as you provide an email address for Let's Encrypt.) They exist in `/var/discourse/shared/standalone/ssl/`:
 
 ```
@@ -307,7 +309,7 @@ root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org
 
 These files must be present for `opensmtpd` to be able to send mail correctly, as per the configuration in `/etc/smtpd.conf`. 
 
-#### 5.2 Test mail delivery
+#### 5.3 Test mail delivery
 
 To create the first admin account on the newly-installed Discourse forum, email delivery must be working, because Discourse will need to send out a confirmation email.
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Or, you can navigate to your droplet's main page, then click the "Console" butto
 
 From here, you can make changes to the server itself. 
 
+> _**NB:** If the initial DNS records haven't propagated yet, you can also SSH directly into the server using its IP address (`ssh root@142.93.152.255`) while you wait._
+
 #### 3.2 Updating the hosts and hostname files
 
 First, connect to the server using either SSH or the built-in DigitalOcean console. Next, edit two files using the text editor of your choice:

--- a/README.md
+++ b/README.md
@@ -423,11 +423,19 @@ Once you send your test message, you can click "View my results" on the mail-tes
 
 Navigate to the page https://{subdomain}.spinalcordmri.org/, and follow the instruction to create an admin email account. Discourse will send you a confirmation email. If you've set up mail correctly, you should receive the email and be able to finish making your account.
 
-#### 5.7 Configure the forum
+Once you log in for the first time, you will be presented with an onboarding flow that will ask for things like "Community name" and "Point of contact". Feel free to put some sensible defaults (e.g. "Spinalcordmri.org", "neuropoly-admin@liste.polymtl.ca", etc.). However, if you will be loading a previous backup of the forum, then these settings will be overwritten anyway, making them moot.
 
-Ideally, we should have a backup of the Discourse forum saved somewhere, such that you can load the backup into the new forum installation and be up and running like normal.
+#### 5.7 Loading a previous backup of the forum
 
-Also, you may want to install important plugins such as `discourse-solved` at this time, too.
+If there is a currently-running instance of the forum, you can download backups from [the Backups page](https://forum.spinalcordmri.org/admin/backups).
+
+Next, you need to upload this backup to the forum. You can try using the Backups page on the dev forum, however sometimes uploads will fail inexplicably with (due to the large size of the backups). So, you may need to instead use [FileZilla to transfer files to the Digital Ocean Droplet](https://docs.digitalocean.com/products/droplets/how-to/transfer-files/). Specifically, the backup will need to be uploaded to the `/var/discourse/shared/standalone/backups/default` folder.
+
+Finally, you will need to enable the "allow restore" setting on the dev server's Settings page. Then, you can return to the Backups page and restore the uploaded backup.
+
+#### 5.8 Installing plugins
+
+Currently, the only mandatory plugin in use by the forum is [`discourse-solved`](https://meta.discourse.org/t/discourse-solved/30155). To install it, please follow the instructions from the [Install Plugins in Discourse](https://meta.discourse.org/t/install-plugins-in-discourse/19157) documentation page.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before you begin, first choose an [FQDN](https://en.wikipedia.org/wiki/Fully_qua
 First, make sure you have an account with DigitalOcean. Next, contact someone on the admin team; they will add you to the [NeuroPoly DigitalOcean team](https://cloud.digitalocean.com/account/team?i=fff1bd). This will grant you access to the [Spinal Cord MRI project](https://cloud.digitalocean.com/projects/12ec554b-d344-44bc-9973-c956f11d032b/resources?i=fff1bd). 
 
 
-##### 1.1 Creating a new droplet
+#### 1.1 Creating a new droplet
 
 From the Spinal Cord MRI project page, you can create a new "droplet", which is DigitalOcean's name for cloud servers.
 
@@ -70,7 +70,7 @@ forum.dev.spinalcordmri.org.
 
 Once you've confirmed that it returns the domain name you chose, you're all set to connect to the droplet.
 
-##### 1.2 Connecting to the droplet for the first time
+#### 1.2 Connecting to the droplet for the first time
 
 You can connect to the server either through SSH (assuming your local device contains the SSH key you added earlier):
 
@@ -96,7 +96,7 @@ First, make sure you have an account with Namecheap. Again, you will need to con
 
 Next, on the dashboard, navigate to the [Advanced DNS tab](https://ap.www.namecheap.com/Domains/DomainControlPanel/spinalcordmri.org/advancedns). Then, modify the following sections:
 
-##### 2.1 Host Records
+#### 2.1 Host Records
 
 First you will want to make note the subdomain label of your domain name. For `forum.dev.spinalcordmri.org`, you will use `forum.dev` to identify your subdomain.
 
@@ -129,7 +129,7 @@ user@device:~$ dig +short TXT _dmarc.forum.dev.spinalcordmri.org
 
 > _**NB**: If you make a mistake and want to update the values of these records, please note that it may take [up to a few hours](https://ns1.com/resources/dns-propagation) for changes to these records to propagate. So, if you're running `dig` and see no change, that's why!_
 
-##### 2.2 Mail Settings (i.e. MX Records)
+#### 2.2 Mail Settings (i.e. MX Records)
 
 Next, scroll down to the "Mail Settings" section and find the table containing MX records. Then, add the following entry:
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ These entries accomplish the following:
 You can double-check the current values by running the following commands:
 
 ```console
-user@device:~$ dig +short forum.spinalcordmri.org
+user@device:~$ dig +short forum.dev.spinalcordmri.org
 142.93.152.255
-user@device:~$ dig +short TXT forum.spinalcordmri.org
+user@device:~$ dig +short TXT forum.dev.spinalcordmri.org
 "v=spf1 a mx ip4:159.89.119.65 include:spf.efwd.registrar-servers.com ~all"
 user@device:~$ dig +short TXT _dmarc.forum.dev.spinalcordmri.org
 "v=DMARC1; p=none"
@@ -230,17 +230,17 @@ If `libcrypto.so.1.1` and `libssl.so.1.1` are linked to `/opt/openssl-1.1.1q/`, 
 Replace the existing contents of  `/etc/smtpd.conf` with the following:
 
 ```
-pki forum.spinalcordmri.org cert "/var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.cer"
-pki forum.spinalcordmri.org key "/var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.key"
+pki forum.dev.spinalcordmri.org cert "/var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.cer"
+pki forum.dev.spinalcordmri.org key "/var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.key"
 
-listen on eth0 tls-require pki forum.spinalcordmri.org
-listen on eth0 tls-require pki forum.spinalcordmri.org auth port 587
+listen on eth0 tls-require pki forum.dev.spinalcordmri.org
+listen on eth0 tls-require pki forum.dev.spinalcordmri.org auth port 587
 table aliases file:/etc/aliases
 
 action "local_mail" maildir "~/.mail" alias <aliases>
 match for local action "local_mail"
 
-action "relay_mail" relay helo "forum.spinalcordmri.org"
+action "relay_mail" relay helo "forum.dev.spinalcordmri.org"
 match from auth for any action "relay_mail"
 ```
 
@@ -274,7 +274,7 @@ We need an SMTP account that Discourse can send mail via. `opensmtpd` simply use
 1. Run a password generator and save the result somewhere secure. (You will need the result for the remainder of this tutorial.)
     - If you have a password manager, see if it has a password generator built in. Otherwise there's [Diceware](https://www.rempe.us/diceware/#eff) and [xkpasswd](https://xkpasswd.net/s/) and [xkcdpass](https://pypi.org/project/xkcdpass/) and [pwgen](https://github.com/tytso/pwgen)
     - Note: Do NOT use symbols in your password. It can cause [weird bugs](https://github.com/neuropoly/computers/issues/403#issuecomment-1341500294) in Discourse's YAML config.
-2. Create the user `forum@forum.spinalcordmri.org` using the following commands:
+2. Create the user `forum@forum.dev.spinalcordmri.org` using the following commands:
     - `useradd -s /usr/sbin/nologin forum` : Creates the user account.
     - `passwd forum`: Sets the password for the account. Paste the password you generated earlier.
 
@@ -300,9 +300,9 @@ cd /var/discourse
 - Install Discourse
 ~~~
 ./discourse-setup
-Hostname      : forum.spinalcordmri.org
+Hostname      : forum.dev.spinalcordmri.org
 Email         : [initial administrator's email address]
-SMTP address  : forum.spinalcordmri.org
+SMTP address  : forum.dev.spinalcordmri.org
 SMTP port     : 587
 SMTP username : forum
 SMTP password : xxxxxxxxxxxxxxxxxxxxxxx
@@ -314,9 +314,9 @@ Let's Encrypt : [initial administrator's email address]
 Before continuing, make sure that Discourse has generated its SSL certs. (They will be [generated automatically](https://meta.discourse.org/t/set-up-https-support-with-lets-encrypt/40709), as long as you provide an email address for Let's Encrypt.) They exist in `/var/discourse/shared/standalone/ssl/`:
 
 ```
-root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.{cer,key}
--rw-r--r-- 1 root root 3799 Dec  5 08:33 /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.cer
--rw------- 1 root root 3247 Dec  5 08:33 /var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.key
+root@forum:~# ls -l /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.{cer,key}
+-rw-r--r-- 1 root root 3799 Dec  5 08:33 /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.cer
+-rw------- 1 root root 3247 Dec  5 08:33 /var/discourse/shared/standalone/ssl/forum.dev.spinalcordmri.org.key
 ```
 
 These files must be present for `opensmtpd` to be able to send mail correctly, as per the configuration in `/etc/smtpd.conf`. 
@@ -347,7 +347,7 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
 
     ```bash
     # You will need to enter the password that you set during the previous "User Setup" section!!
-    swaks --to me@example.com --from noreply@forum.spinalcordmri.org --server forum.spinalcordmri.org -p 587 --auth-user forum --tls-verify --tls
+    swaks --to me@example.com --from noreply@forum.dev.spinalcordmri.org --server forum.dev.spinalcordmri.org -p 587 --auth-user forum --tls-verify --tls
     ```
 
 3. Discourse-specific test
@@ -384,8 +384,8 @@ Go to https://console.developers.google.com, click on Credentials and create a n
 Select Credentials in the left menu, Create credentials and OAuth client ID type for the credentials.
 - Application type `Web application`
 - Name `Forum spinalcordmri.org`
-- Authorized JavaScript origins `http://forum.spinalcordmri.org`
-- Authorized redirect URIs `http://forum.spinalcordmri.org/auth/google_oauth2/callback`
+- Authorized JavaScript origins `http://forum.dev.spinalcordmri.org`
+- Authorized redirect URIs `http://forum.dev.spinalcordmri.org/auth/google_oauth2/callback`
 
 Configure your OAuth Consent Screen
   - Product name shown to users `Forum spinalcordmri.org`
@@ -394,7 +394,7 @@ Configure your OAuth Consent Screen
 
 Click Library in the left menu and you’ll see a huge list of Google API’s. Find Google+ API and enable them.
 
-The API will create `google_client_id` and `google_client_secret` which you can add under http://forum.spinalcordmri.org/admin/site_settings/category/login, after checking `enable google oauth2 logins`
+The API will create `google_client_id` and `google_client_secret` which you can add under http://forum.dev.spinalcordmri.org/admin/site_settings/category/login, after checking `enable google oauth2 logins`
 
 #### 6.2  Configure GitHub login for Discourse ([reference](https://meta.discourse.org/t/configuring-github-login-for-discourse/13745))
 
@@ -405,7 +405,7 @@ Under github.com/spinalcordmri, click Settings (the gear icon), then look for OA
   ~~~
   - Homepage URL
   ~~~
-  http://forum.spinalcordmri.org/
+  http://forum.dev.spinalcordmri.org/
   ~~~
   - Application description
   ~~~
@@ -413,8 +413,8 @@ Under github.com/spinalcordmri, click Settings (the gear icon), then look for OA
   ~~~
   - Authorization callback URL
   ~~~
-  http://forum.spinalcordmri.org//auth/github/callback
+  http://forum.dev.spinalcordmri.org//auth/github/callback
   ~~~
-The app will create `github_client_id` and `github_client_secret`which you can add under http://forum.spinalcordmri.org/admin/site_settings/category/login, after checking `enable github logins`
+The app will create `github_client_id` and `github_client_secret`which you can add under http://forum.dev.spinalcordmri.org/admin/site_settings/category/login, after checking `enable github logins`
 
 </details>

--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ Install [`opensmtpd`](https://www.opensmtpd.org/):
 sudo apt-get install opensmtpd
 ```
 
-The installer might(TODO: check on this) prompt you to name the system; make sure to tell it "forum.spinalcordmri.org".
-Afterwards, make sure that `/etc/mailname` contains "forum.spinalcordmri.org".
+The installer will prompt you to name the system; make sure to tell it "forum.spinalcordmri.org".
 
 **There is a bug** in the OpenSMTPd packaged for Ubuntu 18.04: https://bugs.launchpad.net/ubuntu/+source/opensmtpd/+bug/1840586. To work around it, apply this patch:
 

--- a/README.md
+++ b/README.md
@@ -193,19 +193,21 @@ The installer will prompt you to name the system; make sure to tell it "forum.sp
 
 #### 4.2 Configure mail server
 
-Put this into `/etc/smtpd.conf`:
+Replace the existing contents of  `/etc/smtpd.conf` with the following:
 
 ```
-pki forum.spinalcordmri.org certificate "/var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.cer"
+pki forum.spinalcordmri.org cert "/var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.cer"
 pki forum.spinalcordmri.org key "/var/discourse/shared/standalone/ssl/forum.spinalcordmri.org.key"
 
-listen on eth0 tls-require pki forum.spinalcordmri.org auth-optional
+listen on eth0 tls-require pki forum.spinalcordmri.org
 listen on eth0 tls-require pki forum.spinalcordmri.org auth port 587
 table aliases file:/etc/aliases
-# incoming mail disabled until if/when we want https://meta.discourse.org/t/set-up-reply-via-email-support/14003
-#accept from any for domain "forum.spinalcordmri.org" alias <aliases> deliver to maildir "~/.mail" 
-accept for local alias <aliases> deliver to maildir "~/.mail" 
-accept for any relay hostname "forum.spinalcordmri.org"
+
+action "local_mail" maildir "~/.mail" alias <aliases>
+match for local action "local_mail"
+
+action "relay_mail" relay helo "forum.spinalcordmri.org"
+match from auth for any action "relay_mail"
 ```
 
 Enable the server with

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ root@forum:~# sudo nano /etc/mailname
 forum.dev.spinalcordmri.org
 ```
 
-Additionally, edit the `/etc/hosts` file to ensure that it looks like the following:
+Additionally, edit the `/etc/hosts` file to ensure that the hostname of the server (`forum.dev.spinalcordmri.org`) maps to the server's permanent IP address [instead of `127.0.1.1`](https://qref.sourceforge.net/quick/ch-gateway.en.html#s-net-dns).
 
 ```console
 root@forum:~# sudo nano /etc/hosts
@@ -190,7 +190,7 @@ root@forum:~# sudo nano /etc/hosts
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 #
-127.0.1.1 forum.dev.spinalcordmri.org
+142.93.152.255 forum.dev.spinalcordmri.org
 127.0.0.1 localhost
 
 # The following lines are desirable for IPv6 capable hosts

--- a/README.md
+++ b/README.md
@@ -210,23 +210,32 @@ action "relay_mail" relay helo "forum.spinalcordmri.org"
 match from auth for any action "relay_mail"
 ```
 
-Enable the server with
+#### 4.3 Enable verbose debugging
+
+Edit the following file:
+
+```
+sudo nano /etc/systemd/system/multi-user.target.wants/opensmtpd.service
+```
+
+And make the following change:
+
+```diff
+-ExecStart=/usr/sbin/smtpd
++ExecStart=/usr/sbin/smtpd -v
+```
+
+#### 4.4 Starting the mail server
+
+You can now start the server with the following command:
 
 ```
 systemctl enable --now opensmtpd
 ```
 
-View the logs -- especially to look for configuration errors -- with
+#### 4.5 Create a new mail-specific user account
 
-```
-journalctl -f -u opensmtpd
-```
-
-(it helps to run this in a separate tab while doing the rest of the configuration and testing)
-
-#### 4.3 Create a new mail-specific user account
-
-We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's users by default, so we will make an OS user for outgoing emails.
+We need an SMTP account that Discourse can send mail via. `opensmtpd` simply uses the OS's users by default, so we will make an OS user for outgoing emails.
 
 1. Run a password generator and save the result somewhere secure. (You will need the result for the remainder of this tutorial.)
     - If you have a password manager, see if it has a password generator built in. Otherwise there's [Diceware](https://www.rempe.us/diceware/#eff) and [xkpasswd](https://xkpasswd.net/s/) and [xkcdpass](https://pypi.org/project/xkcdpass/) and [pwgen](https://github.com/tytso/pwgen)

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ We run a small mail server on the same server as Discourse for it to send notifc
 
 #### 4.1 Install mail server
 
-Install [`opensmtpd`](https://www.opensmtpd.org/):
+First, we must install [`opensmtpd`](https://www.opensmtpd.org/). However, we cannot use 
 
 ```
 sudo apt-get install opensmtpd
@@ -287,11 +287,13 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
 
 1. Simple test (`mail`)
 
+    You will first need to install [Mailutils](https://mailutils.org/) using `sudo apt-get install mailutils`. Then, you can run:
+
     ```bash
     echo "Test Message" | mail -s "This is a message" somethingsomething@mail-tester.com
     ```
 
-2. Complex test (`swaks`)
+3. Complex test (`swaks`)
 
     You will first need to install the "Swiss Army Knife for SMTP" ([`swaks`](https://www.jetmore.org/john/code/swaks/)) using `sudo apt-get install swaks`. Then, you can run:
 
@@ -300,7 +302,7 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
     swaks --to me@example.com --from noreply@forum.spinalcordmri.org --server forum.spinalcordmri.org -p 587 --auth-user forum --tls-verify --tls
     ```
 
-3. Discourse-specific test
+4. Discourse-specific test
 
     First, `cd` into `/var/discourse`. Then, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can now use the red "Add New Record" button to add 3 new records in the foll
 Type | Host | Value | TTL
 -- | -- | -- | --
 A Record | {subdomain} | 142.93.152.255 | Automatic
-TXT Record | {subdomain} | v=spf1 a mx ip4:142.93.152.255 include:spf.efwd.registrar-servers.com ~all | Automatic
+TXT Record | {subdomain} | v=spf1 a mx ip4:142.93.152.255 ~all | Automatic
 TXT Record | _dmarc.{subdomain} | v=DMARC1; p=none | Automatic
 
 These entries accomplish the following:

--- a/README.md
+++ b/README.md
@@ -302,17 +302,39 @@ Connect to the droplet server provided by Digital Ocean, then do:
     git clone https://github.com/discourse/discourse_docker.git /var/discourse
     cd /var/discourse
     ```
+- Increase timeout values
+    
+    Before we can install Discourse, we must make a small tweak to the default Discourse Docker container template.
+
+    Open the file `/var/discourse/samples/standalone.yml` and add the following lines to the SMTP section:
+
+    ```diff
+      ## TODO: The SMTP mail server used to validate new accounts and send notifications
+      # SMTP ADDRESS, username, and password are required
+      # WARNING the char '#' in SMTP password can cause problems!
+      DISCOURSE_SMTP_ADDRESS: smtp.example.com
+      #DISCOURSE_SMTP_PORT: 587
+      DISCOURSE_SMTP_USER_NAME: user@example.com
+      DISCOURSE_SMTP_PASSWORD: pa$$word
+    + DISCOURSE_SMTP_OPEN_TIMEOUT: 30
+    + DISCOURSE_SMTP_READ_TIMEOUT: 30
+      #DISCOURSE_SMTP_ENABLE_START_TLS: true           # (optional, default true)
+      #DISCOURSE_SMTP_DOMAIN: discourse.example.com    # (required by some providers)
+      #DISCOURSE_NOTIFICATION_EMAIL: noreply@discourse.example.com    # (address to send notifications from)
+    ```
+  
+    The default values for these options are `5` seconds, which is too strict for our (slower) internal mail server. So, we must increase the timeout [to avoid `Net::ReadTimeout` errors](https://meta.discourse.org/t/smtp-net-readtimeout-without-relation-to-net-or-login-problems-smtp-host-is-just-slow/235727/1).
 - Install Discourse
     ```
     ./discourse-setup
     Hostname        : forum.dev.spinalcordmri.org
-    Email           : [initial administrator's email address]
+    Email           : [initial administrator's email address -- will be used for 1st admin account creation]
     SMTP address    : forum.dev.spinalcordmri.org
     SMTP port       : 587
     SMTP username   : forum
     SMTP password   : xxxxxxxxxxxxxxxxxxxxxxx
     Notification    : noreply@forum.dev.spinalcordmri.org
-    Let's Encrypt   : [initial administrator's email address]
+    Let's Encrypt   : neuropoly-admin@liste.polymtl.ca
     Maxmind License : [Enter]
     ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This repo contains the source code and documentation for the https://spinalcordmri.org/ website. 
 
-The website is written using the Jekyll static site generator, and is deployed and hosted using GitHub Pages. The website uses a custom domain name purchased from NameCheap, then linked with GitHub Pages. (This way, instead of https://spinalcordmri.github.io, we get to use https://spinalcordmri.org.)
+## Main website (`spinalcordmri.org`)
+
+The main website is a simple landing page written using the Jekyll static site generator, and is deployed and hosted using GitHub Pages. The website uses a custom domain name purchased from NameCheap, then linked with GitHub Pages. (This way, instead of https://spinalcordmri.github.io, we get to use https://spinalcordmri.org.)
+
+## Setting up the GitHub Pages site
 
 Configuration settings can be found here:
 
@@ -14,10 +18,19 @@ Configuration is relatively simple, and was done using instructions from the fol
 - **GitHub Pages**: https://help.github.com/articles/quick-start-setting-up-a-custom-domain/
 - **NameCheap**: https://www.namecheap.com/support/knowledgebase/article.aspx/9645/2208/how-do-i-link-my-domain-to-github-pages
 
-## Set up Discourse Forum
+## SCT Forum (`forum.spinalcordmri.org`)
 
-### Reference
-https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md
+The webforum ["forum.spinalcordmri.org"](https://forum.spinalcordmri.org/) is a subdomain of the spinalcordmri.org website. The forum was [originally envisioned](https://github.com/neuropoly/onboarding/issues/71#issuecomment-1008948573) as a general web forum and community for discussing MRI processing, acquisition, etc. That being said, the spinalcordmri.org forum is often colloquially referred to as the "SCT Forum", because the most active part of the forum is the ["SCT"](https://forum.spinalcordmri.org/c/sct/8) subsection. 
+
+The forum runs using the open-source forum software Discourse, and operates within a VM provided by DigitalOcean. This means that it is an entirely separate site from the main website, and so the setup, configuration, and administration of the forum is a bit more involved than the Jekyll part of the site.
+
+## Setting up the SCT Forum
+
+If you need to remake the forum's VM from scratch (e.g. to debug an issue without impacting the production server), then follow the instructions below. 
+
+> _**NB**: The following instructions are heavily based off of Discourse's official Cloud Installation instructions found [here](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md). If anything is unclear, it may be helpful to refer to those instructions for further guidance._
+
+### DigitalOcean
 
 Create account & droplet in Digital Ocean. Droplet configure : 1GB RAM, 1 vCPU,25 GB HDD,	1 TB transfer, running Ubuntu 18.04-LTS.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ```
 
-Finally, ensure that the following command also returns the same domain name as above:
+Reboot the server by running `reboot`, then reconnect and ensure that the following command also returns the same domain name as above:
 
 ```console
 root@forum:~# hostname

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ TXT Record | _dmarc.forum.dev | v=DMARC1; p=none | Automatic
 
 These entries accomplish the following:
 
-1.[A Record](https://support.dnsimple.com/articles/a-record/): Maps the `forum.dev.spinalcordmri.org` subdomain to the DigitalOcean droplet's IP address.
-2.[SPF Record](https://spfrecord.io/syntax/): This will help later on when setting up the forum's mail server. It authorizes the DigitalOcean droplet as a valid sender of mail, which helps prevent the forum's notification emails from being caught as spam.
-3.[DMARC Record](https://mxtoolbox.com/dmarc/details/what-is-a-dmarc-record): This will help later on when setting up the forum's mail server. 
+1. [A Record](https://support.dnsimple.com/articles/a-record/): Maps the `forum.dev.spinalcordmri.org` subdomain to the DigitalOcean droplet's IP address.
+2. [SPF Record](https://spfrecord.io/syntax/): This will help later on when setting up the forum's mail server. It authorizes the DigitalOcean droplet as a valid sender of mail, which helps prevent the forum's notification emails from being caught as spam.
+3. [DMARC Record](https://mxtoolbox.com/dmarc/details/what-is-a-dmarc-record): This will help later on when setting up the forum's mail server. 
 
 You can double-check the current values by running the following commands:
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's
 
 1. Run a password generator and save the result somewhere secure. (You will need the result for the remainder of this tutorial.)
     - If you have a password manager, see if it has a password generator built in. Otherwise there's [Diceware](https://www.rempe.us/diceware/#eff) and [xkpasswd](https://xkpasswd.net/s/) and [xkcdpass](https://pypi.org/project/xkcdpass/) and [pwgen](https://github.com/tytso/pwgen)
+    - Note: Do NOT use symbols in your password. It can cause [weird bugs](https://github.com/neuropoly/computers/issues/403#issuecomment-1341500294) in Discourse's YAML config.
 2. Create the user `forum@forum.spinalcordmri.org` using the following commands:
     - `useradd -s /usr/sbin/nologin forum` : Creates the user account.
     - `passwd forum`: Sets the password for the account. Paste the password you generated earlier.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ If you need to remake the forum's VM from scratch (e.g. to debug an issue withou
 
 ----
 
+- 0. [Domain name](#0-domain-name)
+- 1. [Digital Ocean](#1-digitalocean)
+- 2. [Namecheap](#2-namecheap)
+- 3. [Hostnames](#3-server-setup-hostnames)
+- 4. [Email](#4-server-setup-email)
+- 5. [Discourse](#5-server-setup-discourse)
+- 6. [Google/GitHub logins](#6-googlegithub-logins-for-discourse)
+
+----
+
 ### 0. Domain name
 
 Before you begin, first choose an [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) (i.e. a domain name). This can be `forum.spinalcordmri.org` if you're starting completely from scratch (i.e. there is no currently-running forum instance) or something like `forum.dev.spinalcordmri.org` (if you're setting up a separate test server).

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
     echo "Test Message" | mail -s "This is a message" somethingsomething@mail-tester.com
     ```
 
-3. Complex test (`swaks`)
+2. Complex test (`swaks`)
 
     You will first need to install the "Swiss Army Knife for SMTP" ([`swaks`](https://www.jetmore.org/john/code/swaks/)) using `sudo apt-get install swaks`. Then, you can run:
 
@@ -338,7 +338,7 @@ Go to https://www.mail-tester.com/ and copy the email address it gives you. You 
     swaks --to me@example.com --from noreply@forum.spinalcordmri.org --server forum.spinalcordmri.org -p 587 --auth-user forum --tls-verify --tls
     ```
 
-4. Discourse-specific test
+3. Discourse-specific test
 
     First, `cd` into `/var/discourse`. Then, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -30,23 +30,145 @@ If you need to remake the forum's VM from scratch (e.g. to debug an issue withou
 
 > _**NB**: The following instructions are heavily based off of Discourse's official Cloud Installation instructions found [here](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md). If anything is unclear, it may be helpful to refer to those instructions for further guidance._
 
+### 0. Choosing a domain name
+
+Before you begin, first choose an [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) (i.e. a domain name). This can be `forum.spinalcordmri.org` if you're starting completely from scratch (i.e. there is no currently-running forum instance) or something like `forum.dev.spinalcordmri.org` (if you're setting up a separate test server).
+
+> _**NB**: For the rest of these instructions, we will use the `forum.dev.spinalcordmri.org` hostname, but make sure you substitute in whichever domain name you decided on._
+
 ### 1. DigitalOcean
 
-Create account & droplet in Digital Ocean. Droplet configure : 1GB RAM, 1 vCPU,25 GB HDD,	1 TB transfer, running Ubuntu 18.04-LTS.
+First, make sure you have an account with DigitalOcean. Next, contact someone on the admin team; they will add you to the [NeuroPoly DigitalOcean team](https://cloud.digitalocean.com/account/team?i=fff1bd). This will grant you access to the [Spinal Cord MRI project](https://cloud.digitalocean.com/projects/12ec554b-d344-44bc-9973-c956f11d032b/resources?i=fff1bd). 
+
+
+##### 1.1 Creating a new droplet
+
+From the Spinal Cord MRI project page, you can create a new "droplet", which is DigitalOcean's name for cloud servers.
+
+![image](https://user-images.githubusercontent.com/16181459/207157185-6cc381a1-762c-4db5-8350-e128aec93962.png)
+
+Next, create a droplet using the following settings:
+
+  - **Choose an image**: Distribution -> Ubuntu -> Version: 22.10 x64
+  - **Choose a plan**: 
+    - Shared CPU: Basic
+    - CPU Options: Regular
+    - Price: $6/mo (Specs: 1 GB/1 CPU, 25 GB SSD Disk, 1000 GB Transfer)
+  - **Add block storage**: Skip this step
+  - **Choose a datacenter region**: Toronto 1
+  - **VPC Network**: Skip this step
+  - **Authentication**: If your key isn't present yet, press "New SSH Key" and follow the instructions to authenticate the device you're currently using.
+  - **Select additional options**: Check "Monitoring" and leave the rest blank.
+  - **How many Droplets?**: 1 Droplet
+  - **Choose a hostname**: This is a very critical step! Make sure you enter the same domain name you chose earlier (e.g. `forum.dev.spinalcordmri.org`)
+  - **Add tags**: Skip this step
+
+Once the droplet has finished creating, you should see a public IP address on the droplet's page that looks something like `ipv4: 142.93.152.255`. You can then use this IP address to test that you've set the hostname correctly by running the following command on any linux machine:
+
+```console
+user@device:~$ dig +short -x 142.93.152.255
+forum.dev.spinalcordmri.org.
+```
+
+Once you've confirmed that it returns the domain name you chose, you're all set to connect to the droplet.
+
+##### 1.2 Connecting to the droplet for the first time
+
+You can connect to the server either through SSH (assuming your local device contains the SSH key you added earlier):
+
+```console
+user@device:~$ ssh root@forum.dev.spinalcordmri.org
+Welcome to Ubuntu 22.10 (GNU/Linux 5.19.0-26-generic x86_64)
+
+Last login: Fri Dec  9 23:06:11 2022 from 162.243.188.66
+root@forum:~# 
+```
+
+Or, you can navigate to your droplet's main page, then click the "Console" button in the top-left corner:
+
+![image](https://user-images.githubusercontent.com/16181459/207170763-68db34b0-4f1d-4e6d-a7b6-72340994c7ae.png)
+
+From here, you can make changes to the server itself. 
 
 ### 2. Namecheap
 
-  - To create a subdomain, please do the following:
-    - Go to your Domain List and click Manage next to the domain
-    - Select the Advanced DNS tab
-    - Find the Host Records section and click on the Add New Record button
-    - Select A Record for Type and enter the Host `forum.spinalcordmri.org`  you would like to point to an IP address `DigitalOcean_Server_IP_Address`
+Before we make any changes to the server, we first have to configure some DNS settings.
 
-### 3. System Hostname
+First, make sure you have an account with Namecheap. Again, you will need to contact someone on the admin team; they will grant you permissions for specific domains on a case-by-case basis. In this case, you will want access to the spinalcordmri.org domain, which will grant you access to the [Spinalcordmri.org Dashboard](https://ap.www.namecheap.com/domains/domaincontrolpanel/spinalcordmri.org/domain).
 
-Make sure that the Droplet's `/etc/hostname` contains "forum.spinalcordmri.org".
+Next, on the dashboard, navigate to the [Advanced DNS tab](https://ap.www.namecheap.com/Domains/DomainControlPanel/spinalcordmri.org/advancedns). Then, modify the following sections:
 
-### 4. Setup Discourse server
+##### 2.1 Host Records
+
+First you will want to make note the subdomain label of your domain name. For `forum.dev.spinalcordmri.org`, you will use `forum.dev` to identify your subdomain.
+
+Next, you will want to mark down the IP address you noted in Step 1. For `forum.dev.spinalcordmri.org`, the IP address was `142.93.152.255`.
+
+You can now use the red "Add New Record" button to add 3 new records in the following form:
+
+Type | Host | Value | TTL
+-- | -- | -- | --
+A Record | forum.dev | 142.93.152.255 | Automatic
+TXT Record | forum.dev | v=spf1 a mx ip4:142.93.152.255 include:spf.efwd.registrar-servers.com ~all | Automatic
+TXT Record | _dmarc.forum.dev | v=DMARC1; p=none | Automatic
+
+These entries accomplish the following:
+
+1.[A Record](https://support.dnsimple.com/articles/a-record/): Maps the `forum.dev.spinalcordmri.org` subdomain to the DigitalOcean droplet's IP address.
+2.[SPF Record](https://spfrecord.io/syntax/): This will help later on when setting up the forum's mail server. It authorizes the DigitalOcean droplet as a valid sender of mail, which helps prevent the forum's notification emails from being caught as spam.
+3.[DMARC Record](https://mxtoolbox.com/dmarc/details/what-is-a-dmarc-record): This will help later on when setting up the forum's mail server. 
+
+You can double-check the current values by running the following commands:
+
+```console
+user@device:~$ dig +short forum.spinalcordmri.org
+142.93.152.255
+user@device:~$ dig +short TXT forum.spinalcordmri.org
+"v=spf1 a mx ip4:159.89.119.65 include:spf.efwd.registrar-servers.com ~all"
+user@device:~$ dig +short TXT _dmarc.forum.dev.spinalcordmri.org
+"v=DMARC1; p=none"
+```
+
+> _**NB**: If you make a mistake and want to update the values of these records, please note that it may take [up to a few hours](https://ns1.com/resources/dns-propagation) for changes to these records to propagate. So, if you're running `dig` and see no change, that's why!_
+
+##### 2.2 Mail Settings (i.e. MX Records)
+
+Next, scroll down to the "Mail Settings" section and find the table containing MX records. Then, add the following entry:
+
+Type | Host | Mail Server | Priority | TTL
+-- | -- | -- | -- | --
+MX Record | forum.dev | forum.dev.spinalcordmri.org. | 0 | Automatic
+
+Again, this setting will help us later when we set up our mail server. (There's not much here to talk about, since details such as 'priority' are only really relevant for setups with [multiple mail servers](https://www.cloudflare.com/learning/dns/dns-records/dns-mx-record/).)
+
+You can double-check the current value of this record by running the following command:
+
+```console
+user@device:~$ dig +short MX forum.dev.spinalcordmri.org
+0 forum.dev.spinalcordmri.org.
+```
+
+### 3. Server Setup: Hostnames
+
+Now that NameCheap is configured, we can set up the server itself, starting with its hostname.
+
+First, connect to the server using either SSH or the built-in DigitalOcean console. Next, edit two files using the text editor of your choice:
+
+```console
+root@forum:~# sudo nano /etc/hostname
+forum.dev.spinalcordmri.org
+root@forum:~# sudo nano /etc/hostname
+forum.dev.spinalcordmri.org
+```
+
+Make sure that both of these files contain only the domain name you chose. Additionally, ensure that the following command also returns the same domain name:
+
+```console
+root@forum:~# hostname
+forum.dev.spinalcordmri.org
+```
+
+### 4. Server Setup: Discourse
 
 Connect to the droplet server provided by Digital Ocean, then do:
   * Install Docker:
@@ -121,20 +243,7 @@ Afterwards, make sure that `/etc/mailname` contains "forum.spinalcordmri.org".
 
 Despite this bug, setting up `opensmtpd` is still leagues simpler and more reliable than `postfix` or `sendmail`.
 
-#### 5.2 Setup DNS for Email
-
-1. Again, triple-check that `cat /etc/hostname` and `cat /etc/mailname` and `hostname` all return "forum.spinalcordmri.org"; **if not**, edit those two files manually, then **reboot** and check again.
-1. In NameCheap, under the "forum.spinalcordmri.org" subdomain:
-    1. Define the `MX` record: scroll to the email section, *set* it to "Custom MX" and write in `MX forum = forum.spinalcordmri.org, priority 0`.
-        * to test: `dig MX forum.spinalcordmri.org` should return "forum.spinalcordmri.org"
-    2. Set up [SPF](https://spfrecord.io/syntax/): again in namecheap, in the main records section, add `TXT forum. = "v=spf1 a mx ip4:159.89.119.65 ~all"`
-        * to test: `dig TXT forum.spinalcordmri.org` should return the string above.
-    3. DMARC: again in namecheap, add a record `TXT _dmarc.forum. = "v=DMARC1; p=none"`; but I'm not sure this achieves anything really.
-        * to test: `dig TXT _dmarc.forum.spinalcordmri.org` should return the string above.
-3. Reverse DNS: log in to the Droplet's control panel at DigitalOcean (DO) and *set the name of the Droplet* to "forum.spinalcordmri.org"; this [causes the reverse DNS to be defined](https://www.digitalocean.com/community/questions/how-do-i-set-up-reverse-dns-for-my-ip).
-    * to test: `dig +short -x $(dig +short forum.spinalcordmri.org)` should return "forum.spinalcordmri.org".
-
-#### 5.3 Configure mail server
+#### 5.2 Configure mail server
 
 Put this into `/etc/smtpd.conf`:
 
@@ -166,7 +275,7 @@ journalctl -f -u opensmtpd
 (it helps to run this in a separate tab while doing the rest of the configuration and testing)
 
 
-#### 5.4 Test mail delivery
+#### 5.3 Test mail delivery
 
 At this point the mail server *should* be a member of the internet email community. To test, use:
 
@@ -189,7 +298,7 @@ then click the "View My Results" button.
 
 Review until you have a good score and mails are getting accepted.
 
-#### 5.5 Configure Discourse's email account
+#### 5.4 Configure Discourse's email account
 
 We need an SMTP account Discourse can send via. `opensmtpd` simply uses the OS's users by default, so we will make an OS user for outgoing emails. This username is *not* the same as what's on the email headers: `opensmtpd` allows authenticated users to spoof their identities, and we need actually want that because we want to send as `noreply@forum.spinalcordtoolbox.org`.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,18 @@ Thankfully, one of SCT's developers has created a script that will automate this
 
 > _**NB:**: The `opensmtpd` installer will prompt you to name the system; make sure to tell it "forum.dev.spinalcordmri.org"._
 
+You can verify that `opensmptd` was built and installed correctly by running:
+
+```console
+root@forum:~# ldd `which smtpd`
+    [...]
+	libcrypto.so.1.1 => /opt/openssl-1.1.1q/lib/libcrypto.so.1.1 (0x00007f5ed6eb2000)
+	libssl.so.1.1 => /opt/openssl-1.1.1q/lib/libssl.so.1.1 (0x00007f5ed6e19000)
+    [...]
+```
+
+If `libcrypto.so.1.1` and `libssl.so.1.1` are linked to `/opt/openssl-1.1.1q/`, then you've installed `opensmtpd` correctly.
+
 #### 4.2 Configure mail server
 
 Replace the existing contents of  `/etc/smtpd.conf` with the following:


### PR DESCRIPTION
Prior to this PR, the `README.md` had not been updated since 2020. Yet, the forum no longer runs on Ubuntu 18.04, and several changes have been made to the installation and setup procedure following discussions in:

* https://github.com/neuropoly/computers/issues/394
* https://github.com/neuropoly/computers/issues/403

This PR aims to update the `README.md` so that it contains up-to-date procedures for installing the SCT forum.