### PR TITLE
Add support email to 2023 Workshop page

### DIFF
--- a/_posts/2023-11-20-sct-course.md
+++ b/_posts/2023-11-20-sct-course.md
@@ -31,6 +31,9 @@ The workshop is **free** 🙂
 
 🗒 [Miro board](https://miro.com/app/board/uXjVM0Q5dbY=/?share_link_id=203499920049). This board is used as a visual communication platform. If you have questions/ideas/suggestions to share, please contribute to the board (you will need to create an account and log in). 
 
+## Support
+
+If cannot connect to the meeting, or if you have any trouble installing SCT v6.1, please email sct_developers@googlegroups.com and one of SCT's developers will be happy to help.
 
 ## Agenda
 

--- a/_posts/2023-11-20-sct-course.md
+++ b/_posts/2023-11-20-sct-course.md
@@ -31,9 +31,9 @@ The workshop is **free** 🙂
 
 🗒 [Miro board](https://miro.com/app/board/uXjVM0Q5dbY=/?share_link_id=203499920049). This board is used as a visual communication platform. If you have questions/ideas/suggestions to share, please contribute to the board (you will need to create an account and log in). 
 
-## Support
+#### Support
 
-If cannot connect to the meeting, or if you have any trouble installing SCT v6.1, please email sct_developers@googlegroups.com and one of SCT's developers will be happy to help.
+If you are unable to connect to the meeting, or if you have any trouble installing SCT v6.1, please email sct_developers@googlegroups.com and one of SCT's developers will be happy to help.
 
 ## Agenda
 


### PR DESCRIPTION
I figured that using the SCT Developer Google Group would be easier to coordinate than using a brand new email.

Before merging, though, we should make sure to prune membership of the SCT Developer Google Group ([link](https://groups.google.com/u/1/g/sct_developers/members)), so that we don't send emails to people who have already left the lab.